### PR TITLE
fix: memory field display

### DIFF
--- a/proto/process_extended.go
+++ b/proto/process_extended.go
@@ -65,7 +65,9 @@ func (p *Process) UpdateCPUMemory() {
 	if err != nil {
 		return
 	}
-	outputSplit := strings.Split(strings.TrimSpace(strings.Split(string(output), "\n")[1]), " ")
+	// output separator can be multiple whitespaces
+	// fix: error `parsing "": invalid syntax` in `strconv.ParseFloat`
+	outputSplit := strings.Fields(strings.TrimSpace(strings.Split(string(output), "\n")[1]))
 
 	p.ProcStatus.Cpu = fmt.Sprint(outputSplit[0], "%")
 


### PR DESCRIPTION
fix Error: `parsing "": invalid syntax` in `strconv.ParseFloat`

<img width="917" alt="image" src="https://github.com/dunstorm/pm2-go/assets/6647633/39b9a190-8629-4c66-a4cf-34bfa48740b2">
