### PR TITLE
refactor(restore): integrate daemon spawn in restore command

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
@@ -18,6 +17,7 @@ var restoreCmd = &cobra.Command{
 	Short: "restore previously dumped processes",
 	Long:  `restore previously dumped processes`,
 	Run: func(cmd *cobra.Command, args []string) {
+		master.SpawnDaemon()
 		logger := master.GetLogger()
 
 		dumpFileName := "dump.json"


### PR DESCRIPTION
- Add `master.SpawnDaemon()` call in the `restoreCmd` execution function
- Remove an empty line in the copyright comment at the top of the file
- Maintain existing functionality of the restore command

Fixes issue https://github.com/dunstorm/pm2-go/issues/6